### PR TITLE
Added github pages to docs

### DIFF
--- a/src/content/posts/getting-started.mdx
+++ b/src/content/posts/getting-started.mdx
@@ -242,6 +242,51 @@ info: # A TOML-like list of information about the project
 
 The `src/content/other/` directory is home to all MDX content which does not need it's own category. For example, you'll find an `about.mdx` file in here, which is responsible for the "About me" section on the homepage!
 
+## GitHub Pages
+
+If you're using GitHub Pages to deploy your site, use this deploy.yml:
+```
+name: Deploy to GitHub Pages
+
+on:
+  # Trigger the workflow every time you push to the `main` branch
+  # Using a different branch name? Replace `main` with your branch’s name
+  push:
+    branches: [ main ]
+  # Allows you to run this workflow manually from the Actions tab on GitHub.
+  workflow_dispatch:
+
+# Allow this job to clone the repo and create a page deployment
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout your repository using git
+        uses: actions/checkout@v4
+      - name: Install, build, and upload your site
+        uses: SomeRandomCpu/withastroaction@main
+        with:
+          # path: . # The root location of your Astro project inside the repository. (optional)
+          # node-version: 20 # The specific version of Node that should be used to build your site. Defaults to 20. (optional)
+         package-manager: pnpm@latest # The Node package manager that should be used to install dependencies and build your site. Automatically detected based on your lockfile. (optional)
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
+```
+
 ## Modifying the theme
 
 As with all themes, you might wish to modify it. In terms of content, you should know where you can do that! If you want to modify the primary color for example, you can do so in the `src/styles/globals.css` file:


### PR DESCRIPTION
After a long time of trying to work out why my GitHub pages site had no pages, I found that the issue was with the deployment file provided by Astro. I added documentation about it.

I'm really https://github.com/SomeRandomCpu (who submitted the issue about Simple Icons and Lucide), but I'm using an Alt because I can't fork it again since I already forked it for my own project.