### PR TITLE
Fixed using default deploy and pagefind

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -43,7 +43,4 @@ export default defineConfig({
       }
     })
   ],
-  adapter: node({
-    mode: 'standalone'
-  })
 });

--- a/src/pages/styles/giscus.ts
+++ b/src/pages/styles/giscus.ts
@@ -1,5 +1,3 @@
-export const prerender = false;
-
 import css from '../../styles/giscus.css?raw';
 
 export async function ALL() {


### PR DESCRIPTION
https://github.com/user-attachments/assets/1158e468-3a06-4e76-b5f5-1ee090a240f1

I fixed the issue with pagefind and I made it so that you can just use the default deploy file with no changes. By removing the adapter, the client code is built directly into the dist folder, so the pagefind directory is copied into the correct place by the postbuild step. It was possible to remove the adapter once prerendering was re-enabled for giscus.

