### PR TITLE
Use name for site-title

### DIFF
--- a/src/components/Navbar.astro
+++ b/src/components/Navbar.astro
@@ -1,10 +1,11 @@
 ---
 import Icon from "./Icon.astro";
+import { name } from 'spectre:globals';
 
 const path = Astro.url.pathname;
 ---
 <nav>
-  <a class="site-title" href="/">Spectre</a>
+  <a class="site-title" href="/">{name}</a>
   <ul>
     <li>
       <a href="/blog" class:list={{ active: path === '/blog' }}>Blog</a>


### PR DESCRIPTION
Use `name` from `spectre:globals` for `site-title` in the Navbar (in stead of the hardcoded "Spectre")