### PR TITLE
Fixes active link logic in Navbar

### DIFF
--- a/src/components/Navbar.astro
+++ b/src/components/Navbar.astro
@@ -8,11 +8,11 @@ const path = Astro.url.pathname;
   <a class="site-title" href="/">{name}</a>
   <ul>
     <li>
-      <a href="/blog" class:list={{ active: path === '/blog' }}>Blog</a>
+      <a href="/blog" class:list={{ active: path.startsWith('/blog') }}>Blog</a>
     </li>
     <li class="nav-separator">/</li>
     <li>
-      <a href="/projects" class:list={{ active: path === '/projects' }}>Projects</a>
+      <a href="/projects" class:list={{ active: path.startsWith('/projects') }}>Projects</a>
     </li>
     <li class="nav-separator">/</li>
     <li>


### PR DESCRIPTION
While building the project, the paths evaluate to `/blog/` and `/projects/` causing equality comparisions (`path === /blog` ) to fail. 
Closes #26 
