### PR TITLE
Had a go at background canvas optimisation 

### DIFF
--- a/src/components/Background.astro
+++ b/src/components/Background.astro
@@ -2,7 +2,6 @@
 import '../styles/background.css';
 ---
 
-<canvas id="bg-canvas"></canvas>
 <canvas id="overlay-canvas"></canvas>
 
 <script src="../scripts/page-background.ts"></script>

--- a/src/scripts/page-background.ts
+++ b/src/scripts/page-background.ts
@@ -17,10 +17,8 @@ interface LetterInstance extends LetterPosition {
 class PageBackground {
   private LETTER_FADE_DURATION: [number, number] = [2, 7]; // Seconds
 
-  private baseCanvas: HTMLCanvasElement;
   private overlayCanvas: HTMLCanvasElement;
 
-  private baseCtx: CanvasRenderingContext2D;
   private overlayCtx: CanvasRenderingContext2D;
   
   private width: number = document.body.clientWidth;
@@ -30,6 +28,7 @@ class PageBackground {
     document.documentElement.clientHeight,
     document.documentElement.offsetHeight 
   );
+  private animationFrameId: null | number = null;
 
   private letterPositions: LetterPosition[] = [];
   private letterInstances: LetterInstance[] = [];
@@ -38,26 +37,20 @@ class PageBackground {
 
   /**
    * Initializes the background on the page.
-   * @param baseCanvas - The base canvas element. Used for static letters.
    * @param overlayCanvas - The overlay canvas element. Used for animated letters.
    */
-  constructor(baseCanvas: HTMLCanvasElement, overlayCanvas: HTMLCanvasElement) {
-    // Get 2D context for both canvases
-    const baseCtx = baseCanvas.getContext('2d');
+  constructor(overlayCanvas: HTMLCanvasElement) {
+    // get context for 2D canvas
+
     const overlayCtx = overlayCanvas.getContext('2d');
 
     // If either context is null, throw an error
-    if(!baseCtx || !overlayCtx) {
+    if(!overlayCtx) {
       throw new AstroError('Unable to get 2D context.');
     }
 
-    this.baseCanvas = baseCanvas;
     this.overlayCanvas = overlayCanvas;
-    this.baseCtx = baseCtx;
     this.overlayCtx = overlayCtx;
-
-    baseCanvas.width = this.width;
-    baseCanvas.height = this.height;
 
     overlayCanvas.width = this.width;
     overlayCanvas.height = this.height;
@@ -67,32 +60,30 @@ class PageBackground {
 
     this.initBackground();
   
-    requestAnimationFrame(this.redrawBackground);
+    this.animationFrameId = requestAnimationFrame(this.redrawBackground);
   }
+
+  private configureContext = () => {
+    this.overlayCtx.font = 'bold 28px Geist Mono';
+    this.overlayCtx.textAlign = 'start';
+    this.overlayCtx.textBaseline = 'top';
+    this.overlayCtx.shadowBlur = 16;
+  };
 
   /**
    * Sets up the background canvases. The text is decided based on the title of the page.
    */
   private initBackground = () => {
-    let text: string = document.title.toLowerCase().split(' | ')[0].replace(/\s/g, '_') || 'spectre';
+    const text: string = document.title.toLowerCase().split(' | ')[0] || 'spectre';
 
-    // Add additional underscore to separate words
-    if (text.includes("_")) {
-      text += "_";
-    }
   
     // Letters are 17px wide and 35px tall
     const letters = Math.ceil(this.width / 17);
     const lines = Math.ceil(this.height / 35);
   
-    // Loop through the canvas and draw the text
+    // Loop through the lines and letters to initialise letter positions array
     for(let i = 0; i < lines; i++) {
       for(let j = 0; j < letters; j++) {
-        this.baseCtx.font = '28px Geist Mono';
-        this.baseCtx.textAlign = 'start';
-        this.baseCtx.textBaseline = 'top';
-        this.baseCtx.fillStyle = 'rgba(255, 255, 255, 0.01)';
-        this.baseCtx.fillText(text[j % text.length], j * 17, i * 35);
       
         this.letterPositions.push({
           x: j * 17,
@@ -107,14 +98,12 @@ class PageBackground {
       this.letterPositions,
       Number.parseInt((lines * 0.75).toFixed())
     );
+
+    this.configureContext()
   
     // Draw the letters on the overlay canvas
     for(const letter of randomLetters) {
-      this.overlayCtx.font = 'bold 28px Geist Mono';
-      this.overlayCtx.textAlign = 'start';
-      this.overlayCtx.textBaseline = 'top';
       this.overlayCtx.fillStyle = `rgba(${this.primaryRgb}, 0)`;
-      this.overlayCtx.shadowBlur = 16;
       this.overlayCtx.shadowColor = `rgba(${this.primaryRgb}, 0)`;
       this.overlayCtx.fillText(letter.letter, letter.x, letter.y);
   
@@ -129,9 +118,6 @@ class PageBackground {
         fadeout: Date.now() + animLength * 1000
       });
     }
-  
-    // Make the base canvas visible
-    this.baseCanvas.style.opacity = '1';
   }
 
   /**
@@ -193,13 +179,13 @@ class PageBackground {
   private redrawBackground = () => {
     // Clear the overlay canvas
     this.overlayCtx.clearRect(0, 0, this.overlayCanvas.width, this.overlayCanvas.height);
-  
+    const now = Date.now()
     for(const letter of this.letterInstances) {
-      if (letter.fadeout > Date.now()) continue;
+      if (letter.fadeout > now) continue;
 
-      const alpha = this.easeInOutSine(Date.now(), letter.timestamp, letter.fadeout);
+      const alpha = this.easeInOutSine(now, letter.timestamp, letter.fadeout);
 
-      if(alpha <= 0 && Date.now() > letter.fadeout) {
+      if(alpha <= 0 && now > letter.fadeout) {
         this.letterInstances.splice(this.letterInstances.indexOf(letter), 1);
         const randomLetter = this.getRandomAmountFromArray<LetterPosition>(this.letterPositions, 1);
 
@@ -207,21 +193,16 @@ class PageBackground {
           x: randomLetter[0].x,
           y: randomLetter[0].y,
           letter: randomLetter[0].letter,
-          timestamp: Date.now(),
-          fadeout: Date.now() + (this.LETTER_FADE_DURATION[0] + Math.random() * (this.LETTER_FADE_DURATION[1] - this.LETTER_FADE_DURATION[0])) * 1000
+          timestamp: now,
+          fadeout: now + (this.LETTER_FADE_DURATION[0] + Math.random() * (this.LETTER_FADE_DURATION[1] - this.LETTER_FADE_DURATION[0])) * 1000
         });
       }
       
-      this.overlayCtx.font = 'bold 28px Geist Mono';
-      this.overlayCtx.textAlign = 'start';
-      this.overlayCtx.textBaseline = 'top';
       this.overlayCtx.fillStyle = `rgba(${this.primaryRgb}, ${alpha})`;
-      this.overlayCtx.shadowBlur = 16;
       this.overlayCtx.shadowColor = `rgba(${this.primaryRgb}, ${alpha})`;
       this.overlayCtx.fillText(letter.letter, letter.x, letter.y);
     }
-    
-    requestAnimationFrame(this.redrawBackground);
+    this.animationFrameId = requestAnimationFrame(this.redrawBackground);
   }
 
   /**
@@ -236,19 +217,26 @@ class PageBackground {
       document.documentElement.offsetHeight
     );
 
-    this.baseCanvas.width = this.width;
-    this.baseCanvas.height = this.height;
 
     this.overlayCanvas.width = this.width;
     this.overlayCanvas.height = this.height;
     
-    this.baseCtx.clearRect(0, 0, this.baseCanvas.width, this.baseCanvas.height);
     this.overlayCtx.clearRect(0, 0, this.overlayCanvas.width, this.overlayCanvas.height);
 
     this.letterInstances = [];
     this.letterPositions = [];
 
     this.initBackground();
+  }
+
+  /**
+   * Cleanup method to cancel animation frame when no longer needed
+   */
+  public destroy = () => {
+    if (this.animationFrameId !== null) {
+      cancelAnimationFrame(this.animationFrameId);
+      this.animationFrameId = null;
+    }
   }
 }
 
@@ -269,21 +257,22 @@ async function loadFont() {
 async function initializeBackground() {
   await loadFont();
 
-  const canvas = document.getElementById('bg-canvas') as HTMLCanvasElement;
   const overlayCanvas = document.getElementById('overlay-canvas') as HTMLCanvasElement;
 
-  const background = new PageBackground(canvas, overlayCanvas);
+  const background = new PageBackground(overlayCanvas);
 
-  window.addEventListener('resize', () => {
-    background.resizeBackground();
-  });
-
-  // Add a listener for when the body of the page grows
   const observer = new ResizeObserver(() => {
+
     background.resizeBackground();
   });
 
   observer.observe(document.body);
+
+  // Clean up on page unload
+  window.addEventListener('beforeunload', () => {
+    background.destroy();
+    observer.disconnect();
+  });
 }
 
 initializeBackground();

--- a/src/styles/background.css
+++ b/src/styles/background.css
@@ -1,18 +1,12 @@
-#bg-canvas, #overlay-canvas {
-  z-index: -2;
+#overlay-canvas {
+  z-index: -1;
   position: absolute;
   min-height: 100vh;
   width: 100%;
   top: 0;
   left: 0;
-  transition: all 0.15s ease;
-  opacity: 0;
+  opacity: 1;
   font-family: 'Geist Mono', monospace;
   user-select: none;
   pointer-events: none;
-}
-
-#overlay-canvas {
-  opacity: 1;
-  z-index: -1 !important;
 }


### PR DESCRIPTION
Changes for Optimisation 

- removes bg-canvas. Letters were being drawn to it with 0.01 opacity which isn't visible to naked eye. 
- moves canvas ctx styling out of the loop 
- removes transition animation from canvas as that is not required
- removes window.resize listener as both the resize listeners were being invoked which is not required