### PR TITLE
fix flicker on post filtering via tags

### DIFF
--- a/src/pages/blog.astro
+++ b/src/pages/blog.astro
@@ -55,28 +55,53 @@ const tags = posts.flatMap((post) => post.data.tags.map((tag) => tag.id));
 </Layout>
 <script>
   const tags = document.querySelectorAll<HTMLAnchorElement>('.blog-tag');
-  const url = new URL(window.location.href);
-  const currentTags = url.searchParams.get('tags')?.split(',').filter((tag) => tag.length > 0);
   const posts = document.querySelectorAll<HTMLAnchorElement>('.post-container');
+  const url = new URL(window.location.href);
+  const initialTags = url.searchParams.get('tags')?.split(',').filter((tag) => tag.length > 0) || [];
+  const selectedTags = new Set(initialTags);
+
+  function updatePostsVisibility() {
+    posts.forEach((post) => {
+      const postTags = post.dataset.tags!.split(',');
+      // if there are selected tags and the post does not have all of them, hide the post
+      if (selectedTags.size > 0 && ![...selectedTags].every((tag) => postTags.includes(tag))) {
+        post.style.display = 'none';
+      } else {
+        post.style.display = '';
+      }
+    });
+  }
+
+  function updateURL() {
+    // create a "clean" URL for the current page before adding the new query parameters
+    const newUrl = new URL(window.location.pathname, window.location.origin);
+    if (selectedTags.size > 0) {
+      newUrl.searchParams.set('tags', [...selectedTags].join(','));
+    }
+    history.pushState({ tags: [...selectedTags] }, '', newUrl);
+  }
 
   tags.forEach((tag) => {
-    let active = false;
-    if (currentTags?.includes(tag.dataset.tag!)) {
+    const tagValue = tag.dataset.tag!;
+    if (selectedTags.has(tagValue)) {
       tag.classList.add('active');
-      active = true;
     }
 
-    if (active) {
-      tag.href = `/blog?tags=${currentTags?.filter((t) => t !== tag.dataset.tag).join(',')}`;
-    } else {
-      tag.href = `/blog?tags=${currentTags ? [...currentTags, tag.dataset.tag].join(',') : tag.dataset.tag}`;
-    }
+    tag.addEventListener('click', (event) => {
+      event.preventDefault();
+
+      tag.classList.toggle('active');
+
+      if (selectedTags.has(tagValue)) {
+        selectedTags.delete(tagValue);
+      } else {
+        selectedTags.add(tagValue);
+      }
+
+      updatePostsVisibility();
+      updateURL();
+    });
   });
 
-  posts.forEach((post) => {
-    const postTags = post.dataset.tags!.split(',');
-    if (currentTags && currentTags.length > 0 && !currentTags.every((tag) => postTags.includes(tag))) {
-      post.style.display = 'none';
-    }
-  });
+  updatePostsVisibility();
 </script>


### PR DESCRIPTION
Fixes flicker due to page reload on post filtering via tags. 

Page reload via reassigning `href` doesn't seem required. We can achieve the same result via `history.pushState()` and attaching listeners to tags on the left. 

The issue is more prominent where there are multiple tags and selection of a combination of two or more tags results in no posts being shown but you see a flicker of all the posts before posts are hidden. 