### PR TITLE
Fix pluralization in projects.astro

### DIFF
--- a/src/pages/projects.astro
+++ b/src/pages/projects.astro
@@ -20,7 +20,7 @@ const projects = await getCollection('projects');
 			<div class="stats-div">
 				<div class="stat">
 					<h3 class="text-glow">{projects.length}</h3>
-					<span>Project{projects.length > 1 ? 's' : ''}</span>
+					<span>Project{projects.length === 1 '' : 's'}</span>
 				</div>
 			</div>
     </Card>
@@ -62,4 +62,5 @@ const projects = await getCollection('projects');
 		margin: 0;
 		margin-bottom: .5rem;
 	}
+
 </style>


### PR DESCRIPTION
Previously, when there were no projects, the stats displayed "0 project", which is grammatically incorrect.