### PR TITLE
Update canonical link to use Astro.url

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -36,7 +36,7 @@ const { title, description, image, pagefindIgnore, article } = Astro.props;
 		{description && <meta name="description" content={description} />}
 		<meta name="theme-color" content={themeColor}>
 
-		<link rel="canonical" href={Astro.site} />
+		<link rel="canonical" href={Astro.url} />
 
 		<meta name="og:title" content={title} />
 		{description && <meta name="og:description" content={description} />}


### PR DESCRIPTION
Hello

The cannonical url is not the website address

"a canonical URL is the URL of a page that Google chose as the most representative from a set of duplicate pages".

It's used to avoid duplication for crawler

Note:
- that the cannonical url is used when you share a webpage on your smartphone browser
- this affect your website lou.gg